### PR TITLE
[Session3] エラーが起こる API に変更してエラーハンドリングを実施する

### DIFF
--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		8B433B27262499900041CCCB /* WeatherFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B26262499900041CCCB /* WeatherFetcher.swift */; };
 		8B433B2F2624A86C0041CCCB /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B2E2624A86C0041CCCB /* Weather.swift */; };
 		8B433B342624ABAA0041CCCB /* WeatherViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B332624ABAA0041CCCB /* WeatherViewState.swift */; };
+		8B433B542628EB3B0041CCCB /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B532628EB3B0041CCCB /* AppError.swift */; };
 		8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0926219A4E002C945A /* AppDelegate.swift */; };
 		8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0B26219A4E002C945A /* SceneDelegate.swift */; };
 		8BB14F0E26219A4E002C945A /* WeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0D26219A4E002C945A /* WeatherViewController.swift */; };
@@ -42,6 +43,7 @@
 		8B433B26262499900041CCCB /* WeatherFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherFetcher.swift; sourceTree = "<group>"; };
 		8B433B2E2624A86C0041CCCB /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		8B433B332624ABAA0041CCCB /* WeatherViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherViewState.swift; sourceTree = "<group>"; };
+		8B433B532628EB3B0041CCCB /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		8BB14F0626219A4E002C945A /* YumemiTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YumemiTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BB14F0926219A4E002C945A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8BB14F0B26219A4E002C945A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 		8B433B252624997C0041CCCB /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				8B433B532628EB3B0041CCCB /* AppError.swift */,
 				8B433B26262499900041CCCB /* WeatherFetcher.swift */,
 				8B433B2E2624A86C0041CCCB /* Weather.swift */,
 				8B433B332624ABAA0041CCCB /* WeatherViewState.swift */,
@@ -310,6 +313,7 @@
 				8B433B27262499900041CCCB /* WeatherFetcher.swift in Sources */,
 				8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */,
 				8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */,
+				8B433B542628EB3B0041CCCB /* AppError.swift in Sources */,
 				8B433B2F2624A86C0041CCCB /* Weather.swift in Sources */,
 				8BB14F4F2621A100002C945A /* WeatherView.swift in Sources */,
 				8B433B342624ABAA0041CCCB /* WeatherViewState.swift in Sources */,

--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8B433B2F2624A86C0041CCCB /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B2E2624A86C0041CCCB /* Weather.swift */; };
 		8B433B342624ABAA0041CCCB /* WeatherViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B332624ABAA0041CCCB /* WeatherViewState.swift */; };
 		8B433B542628EB3B0041CCCB /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B532628EB3B0041CCCB /* AppError.swift */; };
+		8B433B5C2628F5990041CCCB /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B5B2628F5990041CCCB /* ErrorAlert.swift */; };
 		8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0926219A4E002C945A /* AppDelegate.swift */; };
 		8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0B26219A4E002C945A /* SceneDelegate.swift */; };
 		8BB14F0E26219A4E002C945A /* WeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0D26219A4E002C945A /* WeatherViewController.swift */; };
@@ -44,6 +45,7 @@
 		8B433B2E2624A86C0041CCCB /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		8B433B332624ABAA0041CCCB /* WeatherViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherViewState.swift; sourceTree = "<group>"; };
 		8B433B532628EB3B0041CCCB /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
+		8B433B5B2628F5990041CCCB /* ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlert.swift; sourceTree = "<group>"; };
 		8BB14F0626219A4E002C945A /* YumemiTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YumemiTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BB14F0926219A4E002C945A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8BB14F0B26219A4E002C945A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 		8BB14F4C2621A097002C945A /* View */ = {
 			isa = PBXGroup;
 			children = (
+				8B433B5B2628F5990041CCCB /* ErrorAlert.swift */,
 				8BB14F4E2621A100002C945A /* WeatherView.swift */,
 			);
 			path = View;
@@ -313,6 +316,7 @@
 				8B433B27262499900041CCCB /* WeatherFetcher.swift in Sources */,
 				8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */,
 				8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */,
+				8B433B5C2628F5990041CCCB /* ErrorAlert.swift in Sources */,
 				8B433B542628EB3B0041CCCB /* AppError.swift in Sources */,
 				8B433B2F2624A86C0041CCCB /* Weather.swift in Sources */,
 				8BB14F4F2621A100002C945A /* WeatherView.swift in Sources */,

--- a/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
@@ -37,11 +37,17 @@ final class WeatherViewController: UIViewController, WeatherViewDelegate {
     }
 
     func reload() {
-        let weather = weatherFetcher.fetch()
-        let viewState = WeatherViewState(weather: weather)
+        do {
+            let weather = try weatherFetcher.fetch()
+            let viewState = WeatherViewState(weather: weather)
 
-        weatherView.setWeatherImage(image: viewState.image,
-                                    color: viewState.color)
+            weatherView.setWeatherImage(image: viewState.image,
+                                        color: viewState.color)
+        } catch let error as AppError {
+            print(error)
+        } catch {
+            assertionFailure("unexpected")
+        }
     }
 }
 

--- a/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
@@ -43,10 +43,31 @@ final class WeatherViewController: UIViewController, WeatherViewDelegate {
 
             weatherView.setWeatherImage(image: viewState.image,
                                         color: viewState.color)
+
         } catch let error as AppError {
-            print(error)
+            let message: String = {
+                switch error {
+                case .invalidParameter:
+                    return "入力された値が不正です"
+
+                case .unknown:
+                    return "不明なエラーです"
+
+                case .unexpected:
+                    return "予期せぬエラーです"
+                }
+            }()
+
+            let alert: UIAlertController = ErrorAlert.createCloseAlert(title: "エラーが発生しました",
+                                                                       message: message)
+
+            present(alert, animated: true)
+
         } catch {
             assertionFailure("unexpected")
+            let alert: UIAlertController = ErrorAlert.createCloseAlert(title: "エラーが発生しました",
+                                                                       message: "予期せぬエラーです")
+            present(alert, animated: true)
         }
     }
 }

--- a/YumemiTraining/YumemiTraining/Model/AppError.swift
+++ b/YumemiTraining/YumemiTraining/Model/AppError.swift
@@ -1,0 +1,14 @@
+//
+//  AppError.swift
+//  YumemiTraining
+//
+//  Created by Daichi Hayashi on 2021/04/16.
+//
+
+import Foundation
+
+enum AppError: Swift.Error {
+    case invalidParameter
+    case unknown
+    case unexpected
+}

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -10,29 +10,39 @@ import Foundation
 import YumemiWeather
 
 protocol WeatherFetcherProtocol {
-    func fetch() -> Weather
+    func fetch() throws -> Weather
 }
 
 final class WeatherFetcher: WeatherFetcherProtocol {
-    func fetch() -> Weather {
-        let fetchedString: String = YumemiWeather.fetchWeather()
-        let weather: Weather = {
-            switch fetchedString {
-            case "sunny":
-                return .sunny
+    func fetch() throws -> Weather {
+        do {
+            let fetchedString: String = try YumemiWeather.fetchWeather(at: "Tokyo")
+            let weather: Weather = {
+                switch fetchedString {
+                case "sunny":
+                    return .sunny
 
-            case "cloudy":
-                return .cloudy
+                case "cloudy":
+                    return .cloudy
 
-            case "rainy":
-                return .rainy
+                case "rainy":
+                    return .rainy
 
-            default:
-                assertionFailure("unexpected string was returned.")
-                return .cloudy
-            }
-        }()
+                default:
+                    assertionFailure("unexpected string was returned.")
+                    return .cloudy
+                }
+            }()
 
-        return weather
+            return weather
+        } catch YumemiWeatherError.invalidParameterError {
+            throw AppError.invalidParameter
+
+        } catch YumemiWeatherError.unknownError {
+            throw AppError.unknown
+
+        } catch {
+            throw AppError.unexpected
+        }
     }
 }

--- a/YumemiTraining/YumemiTraining/View/ErrorAlert.swift
+++ b/YumemiTraining/YumemiTraining/View/ErrorAlert.swift
@@ -1,0 +1,23 @@
+//
+//  ErrorAlert.swift
+//  YumemiTraining
+//
+//  Created by Daichi Hayashi on 2021/04/16.
+//
+
+import Foundation
+import UIKit
+
+// Enum as a namespace
+enum ErrorAlert {
+    /// 閉じる 1 ボタンのアラートを生成
+    static func createCloseAlert(title: String, message: String) -> UIAlertController {
+        let alert: UIAlertController = UIAlertController(title: title,
+                                                         message: message,
+                                                         preferredStyle: .alert)
+        let closeAction: UIAlertAction = UIAlertAction(title: "閉じる", style: .default)
+        alert.addAction(closeAction)
+
+        return alert
+    }
+}


### PR DESCRIPTION
## Overview

- [課題内容](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Error.md)
- `throws` ver に変更
- エラーを定義して `UIAlertController` によってエラーハンドリングを実施

## Reviews

- エラーハンドリングの内容

## Screenshots

修正前と View 自体は変更ないので、エラーアラートの動作だけ修正後のものを添付。

https://user-images.githubusercontent.com/31601805/114947295-d79b8800-9e87-11eb-9acb-6f53e9a3e0f5.mov
