### PR TITLE
[Session4] Json 文字列の入出力を利用して気温を表示するように機能を追加

### DIFF
--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		8B433B342624ABAA0041CCCB /* WeatherViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B332624ABAA0041CCCB /* WeatherViewState.swift */; };
 		8B433B542628EB3B0041CCCB /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B532628EB3B0041CCCB /* AppError.swift */; };
 		8B433B5C2628F5990041CCCB /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B5B2628F5990041CCCB /* ErrorAlert.swift */; };
+		8B433B6A262A45E00041CCCB /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B69262A45E00041CCCB /* WeatherResponse.swift */; };
 		8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0926219A4E002C945A /* AppDelegate.swift */; };
 		8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0B26219A4E002C945A /* SceneDelegate.swift */; };
 		8BB14F0E26219A4E002C945A /* WeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0D26219A4E002C945A /* WeatherViewController.swift */; };
@@ -46,6 +47,7 @@
 		8B433B332624ABAA0041CCCB /* WeatherViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherViewState.swift; sourceTree = "<group>"; };
 		8B433B532628EB3B0041CCCB /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		8B433B5B2628F5990041CCCB /* ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlert.swift; sourceTree = "<group>"; };
+		8B433B69262A45E00041CCCB /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
 		8BB14F0626219A4E002C945A /* YumemiTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YumemiTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BB14F0926219A4E002C945A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8BB14F0B26219A4E002C945A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				8B433B26262499900041CCCB /* WeatherFetcher.swift */,
 				8B433B2E2624A86C0041CCCB /* Weather.swift */,
 				8B433B332624ABAA0041CCCB /* WeatherViewState.swift */,
+				8B433B69262A45E00041CCCB /* WeatherResponse.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8BB14F0E26219A4E002C945A /* WeatherViewController.swift in Sources */,
+				8B433B6A262A45E00041CCCB /* WeatherResponse.swift in Sources */,
 				8B433B27262499900041CCCB /* WeatherFetcher.swift in Sources */,
 				8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */,
 				8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */,

--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		8B433B542628EB3B0041CCCB /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B532628EB3B0041CCCB /* AppError.swift */; };
 		8B433B5C2628F5990041CCCB /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B5B2628F5990041CCCB /* ErrorAlert.swift */; };
 		8B433B6A262A45E00041CCCB /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B69262A45E00041CCCB /* WeatherResponse.swift */; };
+		8B879CF4262BD7C100D5F5FC /* DateFormatterUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B879CF3262BD7C100D5F5FC /* DateFormatterUtil.swift */; };
 		8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0926219A4E002C945A /* AppDelegate.swift */; };
 		8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0B26219A4E002C945A /* SceneDelegate.swift */; };
 		8BB14F0E26219A4E002C945A /* WeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0D26219A4E002C945A /* WeatherViewController.swift */; };
@@ -48,6 +49,7 @@
 		8B433B532628EB3B0041CCCB /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		8B433B5B2628F5990041CCCB /* ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlert.swift; sourceTree = "<group>"; };
 		8B433B69262A45E00041CCCB /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
+		8B879CF3262BD7C100D5F5FC /* DateFormatterUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterUtil.swift; sourceTree = "<group>"; };
 		8BB14F0626219A4E002C945A /* YumemiTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YumemiTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BB14F0926219A4E002C945A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8BB14F0B26219A4E002C945A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -102,6 +104,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		8B879CF2262BD79C00D5F5FC /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				8B879CF3262BD7C100D5F5FC /* DateFormatterUtil.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
 		8BB14EFD26219A4E002C945A = {
 			isa = PBXGroup;
 			children = (
@@ -125,6 +135,7 @@
 		8BB14F0826219A4E002C945A /* YumemiTraining */ = {
 			isa = PBXGroup;
 			children = (
+				8B879CF2262BD79C00D5F5FC /* Utility */,
 				8B433B252624997C0041CCCB /* Model */,
 				8BB14F4C2621A097002C945A /* View */,
 				8BB14F4D2621A0A6002C945A /* Controller */,
@@ -319,6 +330,7 @@
 				8B433B6A262A45E00041CCCB /* WeatherResponse.swift in Sources */,
 				8B433B27262499900041CCCB /* WeatherFetcher.swift in Sources */,
 				8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */,
+				8B879CF4262BD7C100D5F5FC /* DateFormatterUtil.swift in Sources */,
 				8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */,
 				8B433B5C2628F5990041CCCB /* ErrorAlert.swift in Sources */,
 				8B433B542628EB3B0041CCCB /* AppError.swift in Sources */,

--- a/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class WeatherViewController: UIViewController, WeatherViewDelegate {
 
     private let weatherView: WeatherViewProtocol = WeatherView()
-    private let weatherFetcher: WeatherFetcherProtocol = WeatherFetcher()
+    private let weatherFetcher: WeatherFetcherProtocol = WeatherFetcher(dateFormatter: DateFormatterUtil())
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,16 +39,21 @@ final class WeatherViewController: UIViewController, WeatherViewDelegate {
     func reload() {
         do {
             let weather = try weatherFetcher.fetch()
-            let viewState = WeatherViewState(weather: weather)
+            let viewState = WeatherViewState(weather: weather.weather)
 
             weatherView.setWeatherImage(image: viewState.image,
                                         color: viewState.color)
+            weatherView.setTemperature(max: weather.maxTemperature,
+                                       min: weather.minTemperature)
 
         } catch let error as AppError {
             let message: String = {
                 switch error {
                 case .invalidParameter:
                     return "入力された値が不正です"
+
+                case .parse:
+                    return "情報の変換に失敗しました"
 
                 case .unknown:
                     return "不明なエラーです"

--- a/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
@@ -38,13 +38,13 @@ final class WeatherViewController: UIViewController, WeatherViewDelegate {
 
     func reload() {
         do {
-            let weather = try weatherFetcher.fetch()
-            let viewState = WeatherViewState(weather: weather.weather)
+            let viewEntity = try weatherFetcher.fetch()
+            let viewState = WeatherViewState(weather: viewEntity.weather)
 
             weatherView.setWeatherImage(image: viewState.image,
                                         color: viewState.color)
-            weatherView.setTemperature(max: weather.maxTemperature,
-                                       min: weather.minTemperature)
+            weatherView.setTemperature(max: viewEntity.maxTemperature,
+                                       min: viewEntity.minTemperature)
 
         } catch let error as AppError {
             let message: String = {

--- a/YumemiTraining/YumemiTraining/Model/AppError.swift
+++ b/YumemiTraining/YumemiTraining/Model/AppError.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum AppError: Swift.Error {
     case invalidParameter
+    case parse
     case unknown
     case unexpected
 }

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -31,7 +31,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
         do {
             let nowDateString: String = dateFormatter.createString(from: Date())
             let inputJsonString: String = #"{"area": "Tokyo", "date": "\#(nowDateString)"}"#
-            let fetchedData: Data = try YumemiWeather.fetchWeather(inputJsonString).data(using: .utf8)!
+            let fetchedData: Data = try Data(YumemiWeather.fetchWeather(inputJsonString).utf8)
 
             let response = try parseWeatherResponse(from: fetchedData)
 

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -30,10 +30,10 @@ final class WeatherFetcher: WeatherFetcherProtocol {
     func fetch() throws -> WeatherResponse {
         do {
             let nowDateString: String = dateFormatter.createString(from: Date())
-            let inputJsonString: String = #"{"area": "tokyo", "date": "\#(nowDateString)"}"#
+            let inputJsonString: String = #"{"area": "Tokyo", "date": "\#(nowDateString)"}"#
             let fetchedData: Data = try YumemiWeather.fetchWeather(inputJsonString).data(using: .utf8)!
 
-            let response = try! parseWeatherResponse(from: fetchedData)
+            let response = try parseWeatherResponse(from: fetchedData)
 
             return response
         } catch YumemiWeatherError.invalidParameterError {
@@ -41,6 +41,9 @@ final class WeatherFetcher: WeatherFetcherProtocol {
 
         } catch YumemiWeatherError.unknownError {
             throw AppError.unknown
+
+        } catch AppError.parse {
+            throw AppError.parse
 
         } catch {
             throw AppError.unexpected

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -50,7 +50,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
         }
     }
 
-    private func createWeather(from string: String) throws -> Weather {
+    private func createWeather(from string: String) -> Weather? {
         switch string {
         case "sunny":
             return .sunny
@@ -62,7 +62,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
             return .rainy
 
         default:
-            throw AppError.parse
+            return nil
         }
     }
 
@@ -70,6 +70,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
         do {
             guard let jsonDictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let weatherValue = jsonDictionary["weather"] as? String,
+                  let weather = createWeather(from: weatherValue),
                   let maxTempValue = jsonDictionary["max_temp"] as? Int,
                   let minTempValue = jsonDictionary["min_temp"] as? Int,
                   let dateValue = jsonDictionary["date"] as? String,
@@ -78,7 +79,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
             }
 
             let response = WeatherResponse(
-                weather: try createWeather(from: weatherValue),
+                weather: weather,
                 maxTemperature: maxTempValue,
                 minTemperature: minTempValue,
                 date: date

--- a/YumemiTraining/YumemiTraining/Model/WeatherResponse.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherResponse.swift
@@ -1,0 +1,15 @@
+//
+//  WeatherResponse.swift
+//  YumemiTraining
+//
+//  Created by Daichi Hayashi on 2021/04/17.
+//
+
+import Foundation
+
+struct WeatherResponse {
+    let weather: Weather
+    let maxTemperature: Int
+    let minTemperature: Int
+    let date: Date
+}

--- a/YumemiTraining/YumemiTraining/Utility/DateFormatterUtil.swift
+++ b/YumemiTraining/YumemiTraining/Utility/DateFormatterUtil.swift
@@ -1,0 +1,50 @@
+//
+//  DateFormatterUtil.swift
+//  YumemiTraining
+//
+//  Created by Daichi Hayashi on 2021/04/18.
+//
+
+import Foundation
+
+protocol DateFormatterUtilProtocol {
+    /// ISO8601 形式フォーマッティングの Option を追加設定する
+    func setOptions(with options: [ISO8601DateFormatter.Options])
+    /// ISO8601 形式フォーマッティングの Option を削除設定する
+    func removeOptions(with options: [ISO8601DateFormatter.Options])
+    /// Date から ISO8601 形式の String を生成する
+    func createString(from date: Date) -> String
+    /// ISO8601 形式の String から Date を生成する
+    /// - Parameter string: 変換元の ISO8601 形式文字列
+    /// - returns: Date (入力が不正な形式の場合は nil を返す)
+    func createDate(from string: String) -> Date?
+}
+
+class DateFormatterUtil: DateFormatterUtilProtocol {
+
+    // MARK: - Private property
+
+    private let formatter: ISO8601DateFormatter = ISO8601DateFormatter()
+
+    // MARK: - DateFormatterUtilProtocol
+
+    func setOptions(with options: [ISO8601DateFormatter.Options]) {
+        options.forEach { option in
+            formatter.formatOptions.insert(option)
+        }
+    }
+
+    func removeOptions(with options: [ISO8601DateFormatter.Options]) {
+        options.forEach { option in
+            formatter.formatOptions.remove(option)
+        }
+    }
+
+    func createString(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+
+    func createDate(from string: String) -> Date? {
+        formatter.date(from: string)
+    }
+}

--- a/YumemiTraining/YumemiTraining/View/WeatherView.swift
+++ b/YumemiTraining/YumemiTraining/View/WeatherView.swift
@@ -16,6 +16,7 @@ protocol WeatherViewProtocol: UIView {
     var delegate: WeatherViewDelegate? { get set }
 
     func setWeatherImage(image: UIImage, color: UIColor)
+    func setTemperature(max: Int?, min: Int?)
 }
 
 final class WeatherView: UIView, WeatherViewProtocol {
@@ -135,5 +136,15 @@ final class WeatherView: UIView, WeatherViewProtocol {
     func setWeatherImage(image: UIImage, color: UIColor) {
         weatherImageView.image = image
         weatherImageView.tintColor = color
+    }
+
+    func setTemperature(max: Int?, min: Int?) {
+        if let max = max {
+            maxTemperatureLabel.text = String(describing: max)
+        }
+
+        if let min = min {
+            minTemperatureLabel.text = String(describing: min)
+        }
     }
 }


### PR DESCRIPTION
## Overview

- [課題内容](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Json.md)
- `YumemiWeather.fetch` において入出力を Json 文字列によって行うように修正
  - このときの Parsing には `JSONSerialization` を使用している (`Codable` は次回以降の Session であるので)
- 日付の規格は `ISO8601` であり、 `Date` と `String` の相互変換を用意にするための `DateFormatterUtil` クラスを追加
- 気温と日時がレスポンスと返ってくるので、 `Weather` を内包した `WeatherResponse` 構造体を定義

## Reviews



## Screenshots

| Before | After |
|--------|-------|
| <img width="440" alt="スクリーンショット 2021-04-18 13 09 01" src="https://user-images.githubusercontent.com/31601805/115133969-4115c500-a047-11eb-9635-e4c565de2082.png"> | <img width="440" alt="スクリーンショット 2021-04-18 13 08 17" src="https://user-images.githubusercontent.com/31601805/115133960-26435080-a047-11eb-9b03-8326088c12c1.png"> |
