### PR TITLE
[Session5] Codable を使用した JSON パースに変更

### DIFF
--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8B433B6A262A45E00041CCCB /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B69262A45E00041CCCB /* WeatherResponse.swift */; };
 		8B879CF4262BD7C100D5F5FC /* DateFormatterUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B879CF3262BD7C100D5F5FC /* DateFormatterUtil.swift */; };
 		8B879D08262BF0AE00D5F5FC /* WeatherViewEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B879D07262BF0AE00D5F5FC /* WeatherViewEntity.swift */; };
+		8B879D12262BF70C00D5F5FC /* WeatherPostObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B879D11262BF70C00D5F5FC /* WeatherPostObject.swift */; };
 		8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0926219A4E002C945A /* AppDelegate.swift */; };
 		8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0B26219A4E002C945A /* SceneDelegate.swift */; };
 		8BB14F0E26219A4E002C945A /* WeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0D26219A4E002C945A /* WeatherViewController.swift */; };
@@ -52,6 +53,7 @@
 		8B433B69262A45E00041CCCB /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
 		8B879CF3262BD7C100D5F5FC /* DateFormatterUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterUtil.swift; sourceTree = "<group>"; };
 		8B879D07262BF0AE00D5F5FC /* WeatherViewEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherViewEntity.swift; sourceTree = "<group>"; };
+		8B879D11262BF70C00D5F5FC /* WeatherPostObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherPostObject.swift; sourceTree = "<group>"; };
 		8BB14F0626219A4E002C945A /* YumemiTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YumemiTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BB14F0926219A4E002C945A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8BB14F0B26219A4E002C945A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				8B433B332624ABAA0041CCCB /* WeatherViewState.swift */,
 				8B433B69262A45E00041CCCB /* WeatherResponse.swift */,
 				8B879D07262BF0AE00D5F5FC /* WeatherViewEntity.swift */,
+				8B879D11262BF70C00D5F5FC /* WeatherPostObject.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -340,6 +343,7 @@
 				8B433B2F2624A86C0041CCCB /* Weather.swift in Sources */,
 				8BB14F4F2621A100002C945A /* WeatherView.swift in Sources */,
 				8B879D08262BF0AE00D5F5FC /* WeatherViewEntity.swift in Sources */,
+				8B879D12262BF70C00D5F5FC /* WeatherPostObject.swift in Sources */,
 				8B433B342624ABAA0041CCCB /* WeatherViewState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		8B433B5C2628F5990041CCCB /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B5B2628F5990041CCCB /* ErrorAlert.swift */; };
 		8B433B6A262A45E00041CCCB /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B433B69262A45E00041CCCB /* WeatherResponse.swift */; };
 		8B879CF4262BD7C100D5F5FC /* DateFormatterUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B879CF3262BD7C100D5F5FC /* DateFormatterUtil.swift */; };
+		8B879D08262BF0AE00D5F5FC /* WeatherViewEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B879D07262BF0AE00D5F5FC /* WeatherViewEntity.swift */; };
 		8BB14F0A26219A4E002C945A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0926219A4E002C945A /* AppDelegate.swift */; };
 		8BB14F0C26219A4E002C945A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0B26219A4E002C945A /* SceneDelegate.swift */; };
 		8BB14F0E26219A4E002C945A /* WeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB14F0D26219A4E002C945A /* WeatherViewController.swift */; };
@@ -50,6 +51,7 @@
 		8B433B5B2628F5990041CCCB /* ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlert.swift; sourceTree = "<group>"; };
 		8B433B69262A45E00041CCCB /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
 		8B879CF3262BD7C100D5F5FC /* DateFormatterUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterUtil.swift; sourceTree = "<group>"; };
+		8B879D07262BF0AE00D5F5FC /* WeatherViewEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherViewEntity.swift; sourceTree = "<group>"; };
 		8BB14F0626219A4E002C945A /* YumemiTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YumemiTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BB14F0926219A4E002C945A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8BB14F0B26219A4E002C945A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 				8B433B2E2624A86C0041CCCB /* Weather.swift */,
 				8B433B332624ABAA0041CCCB /* WeatherViewState.swift */,
 				8B433B69262A45E00041CCCB /* WeatherResponse.swift */,
+				8B879D07262BF0AE00D5F5FC /* WeatherViewEntity.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -336,6 +339,7 @@
 				8B433B542628EB3B0041CCCB /* AppError.swift in Sources */,
 				8B433B2F2624A86C0041CCCB /* Weather.swift in Sources */,
 				8BB14F4F2621A100002C945A /* WeatherView.swift in Sources */,
+				8B879D08262BF0AE00D5F5FC /* WeatherViewEntity.swift in Sources */,
 				8B433B342624ABAA0041CCCB /* WeatherViewState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -100,12 +100,12 @@
 			isa = PBXGroup;
 			children = (
 				8B433B532628EB3B0041CCCB /* AppError.swift */,
-				8B433B26262499900041CCCB /* WeatherFetcher.swift */,
 				8B433B2E2624A86C0041CCCB /* Weather.swift */,
-				8B433B332624ABAA0041CCCB /* WeatherViewState.swift */,
+				8B433B26262499900041CCCB /* WeatherFetcher.swift */,
+				8B879D11262BF70C00D5F5FC /* WeatherPostObject.swift */,
 				8B433B69262A45E00041CCCB /* WeatherResponse.swift */,
 				8B879D07262BF0AE00D5F5FC /* WeatherViewEntity.swift */,
-				8B879D11262BF70C00D5F5FC /* WeatherPostObject.swift */,
+				8B433B332624ABAA0041CCCB /* WeatherViewState.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";

--- a/YumemiTraining/YumemiTraining.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/yumemi-inc/ios-training.git",
         "state": {
           "branch": null,
-          "revision": "9c48a93d9a1fd973cd8395bea7a7d982d284cb73",
-          "version": "1.0.3"
+          "revision": "fe33d2f97ef9d35b1c8650a0abc19cb18e4f8e6a",
+          "version": "1.0.4"
         }
       }
     ]

--- a/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
@@ -9,14 +9,20 @@ import UIKit
 
 final class WeatherViewController: UIViewController, WeatherViewDelegate {
 
+    // MARK: - Private property
+
     private let weatherView: WeatherViewProtocol = WeatherView()
     private let weatherFetcher: WeatherFetcherProtocol = WeatherFetcher(dateFormatter: DateFormatterUtil())
+
+    // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         setupWeatherView()
     }
+
+    // MARK: - Private method
 
     private func setupWeatherView() {
         view.addSubview(weatherView)

--- a/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
@@ -38,7 +38,10 @@ final class WeatherViewController: UIViewController, WeatherViewDelegate {
 
     func reload() {
         do {
-            let viewEntity = try weatherFetcher.fetch()
+            let response = try weatherFetcher.fetch()
+            let viewEntity = WeatherViewEntity(weather: response.weather,
+                                               maxTemperature: response.maxTemperature,
+                                               minTemperature: response.minTemperature)
             let viewState = WeatherViewState(weather: viewEntity.weather)
 
             weatherView.setWeatherImage(image: viewState.image,

--- a/YumemiTraining/YumemiTraining/Model/Weather.swift
+++ b/YumemiTraining/YumemiTraining/Model/Weather.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum Weather {
+enum Weather: String, Decodable {
     case sunny
     case rainy
     case cloudy

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -35,6 +35,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
             let response = try parseWeatherResponse(from: fetchedData)
 
             return response
+
         } catch YumemiWeatherError.invalidParameterError {
             throw AppError.invalidParameter
 
@@ -71,6 +72,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
             let value: WeatherResponse = try decoder.decode(WeatherResponse.self, from: data)
 
             return value
+
         } catch {
             throw AppError.parse
         }
@@ -86,6 +88,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
             let data: Data = try encoder.encode(object)
 
             return String(decoding: data, as: UTF8.self)
+
         } catch {
             throw AppError.parse
         }

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -29,8 +29,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
 
     func fetch() throws -> WeatherResponse {
         do {
-            let nowDateString: String = dateFormatter.createString(from: Date())
-            let inputJsonString: String = #"{"area": "Tokyo", "date": "\#(nowDateString)"}"#
+            let inputJsonString: String = try createPostJSONString(with: Date())
             let fetchedData: Data = try Data(YumemiWeather.fetchWeather(inputJsonString).utf8)
 
             let response = try parseWeatherResponse(from: fetchedData)
@@ -72,6 +71,21 @@ final class WeatherFetcher: WeatherFetcherProtocol {
             let value: WeatherResponse = try decoder.decode(WeatherResponse.self, from: data)
 
             return value
+        } catch {
+            throw AppError.parse
+        }
+    }
+
+    private func createPostJSONString(with date: Date) throws -> String {
+        do {
+            let encoder: JSONEncoder = JSONEncoder()
+            let dateString: String = dateFormatter.createString(from: date)
+            let object: WeatherPostObject = WeatherPostObject(area: "Tokyo",
+                                                              dateString: dateString)
+
+            let data: Data = try encoder.encode(object)
+
+            return String(data: data, encoding: .utf8)!
         } catch {
             throw AppError.parse
         }

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -68,23 +68,10 @@ final class WeatherFetcher: WeatherFetcherProtocol {
 
     private func parseWeatherResponse(from data: Data) throws -> WeatherResponse {
         do {
-            guard let jsonDictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let weatherValue = jsonDictionary["weather"] as? String,
-                  let weather = createWeather(from: weatherValue),
-                  let maxTempValue = jsonDictionary["max_temp"] as? Int,
-                  let minTempValue = jsonDictionary["min_temp"] as? Int,
-                  let dateString = jsonDictionary["date"] as? String else {
-                throw AppError.parse
-            }
+            let decoder: JSONDecoder = JSONDecoder()
+            let value: WeatherResponse = try decoder.decode(WeatherResponse.self, from: data)
 
-            let response = WeatherResponse(
-                weather: weather,
-                maxTemperature: maxTempValue,
-                minTemperature: minTempValue,
-                dateString: dateString
-            )
-
-            return response
+            return value
         } catch {
             throw AppError.parse
         }

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -85,7 +85,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
 
             let data: Data = try encoder.encode(object)
 
-            return String(data: data, encoding: .utf8)!
+            return String(decoding: data, as: UTF8.self)
         } catch {
             throw AppError.parse
         }

--- a/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherFetcher.swift
@@ -73,8 +73,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
                   let weather = createWeather(from: weatherValue),
                   let maxTempValue = jsonDictionary["max_temp"] as? Int,
                   let minTempValue = jsonDictionary["min_temp"] as? Int,
-                  let dateValue = jsonDictionary["date"] as? String,
-                  let date = dateFormatter.createDate(from: dateValue) else {
+                  let dateString = jsonDictionary["date"] as? String else {
                 throw AppError.parse
             }
 
@@ -82,7 +81,7 @@ final class WeatherFetcher: WeatherFetcherProtocol {
                 weather: weather,
                 maxTemperature: maxTempValue,
                 minTemperature: minTempValue,
-                date: date
+                dateString: dateString
             )
 
             return response

--- a/YumemiTraining/YumemiTraining/Model/WeatherPostObject.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherPostObject.swift
@@ -1,0 +1,18 @@
+//
+//  WeatherPostObject.swift
+//  YumemiTraining
+//
+//  Created by Daichi Hayashi on 2021/04/18.
+//
+
+import Foundation
+
+struct WeatherPostObject: Encodable {
+    let area: String
+    let dateString: String
+
+    enum CodingKeys: String, CodingKey {
+        case area
+        case dateString = "date"
+    }
+}

--- a/YumemiTraining/YumemiTraining/Model/WeatherResponse.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherResponse.swift
@@ -7,9 +7,16 @@
 
 import Foundation
 
-struct WeatherResponse {
+struct WeatherResponse: Decodable {
     let weather: Weather
     let maxTemperature: Int
     let minTemperature: Int
-    let date: Date
+    let dateString: String
+
+    private enum CodingKeys: String, CodingKey {
+        case weather
+        case maxTemperature = "max_temp"
+        case minTemperature = "min_temp"
+        case dateString = "date"
+    }
 }

--- a/YumemiTraining/YumemiTraining/Model/WeatherViewEntity.swift
+++ b/YumemiTraining/YumemiTraining/Model/WeatherViewEntity.swift
@@ -1,0 +1,14 @@
+//
+//  WeatherViewEntity.swift
+//  YumemiTraining
+//
+//  Created by Daichi Hayashi on 2021/04/18.
+//
+
+import Foundation
+
+struct WeatherViewEntity {
+    let weather: Weather
+    let maxTemperature: Int
+    let minTemperature: Int
+}


### PR DESCRIPTION
## Overview

- [課題内容]
- JSON のパースを `JSONSerialization` → `Codable` + `JSONDecoder` + `JSONEncoder` に変更
  - `YumemiWeather.fetch` の入力オブジェクトは `WeatherPostObject: Encodable`
  - 出力オブジェクトは `WeatherResponse: Decodable`

## Reviews



## Screenshots

見た目の変化なし
