### PR TITLE
[Session7] アプリがバックグラウンドからフォアグラウンドになったときに天気を更新する

### DIFF
--- a/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controller/WeatherViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Daichi Hayashi on 2021/04/10.
 //
 
+import Foundation
 import UIKit
 
 final class WeatherViewController: UIViewController, WeatherViewDelegate {
@@ -20,6 +21,7 @@ final class WeatherViewController: UIViewController, WeatherViewDelegate {
         super.viewDidLoad()
 
         setupWeatherView()
+        setupNotificationCenter()
     }
 
     // MARK: - Private method
@@ -37,11 +39,20 @@ final class WeatherViewController: UIViewController, WeatherViewDelegate {
         ])
     }
 
+    private func setupNotificationCenter() {
+        let center: NotificationCenter = NotificationCenter.default
+        center.addObserver(self,
+                           selector: #selector(reload),
+                           name: UIApplication.didBecomeActiveNotification,
+                           object: nil)
+    }
+
     // MARK: - WeatherViewDelegate
     func close() {
         dismiss(animated: true)
     }
 
+    @objc
     func reload() {
         do {
             let response = try weatherFetcher.fetch()


### PR DESCRIPTION
## Overview

NotificationCenter を利用してアプリがフォアグラウンドに入ったときのイベントを監視し、発火タイミングで `reload()` を呼び出すようにした。

## Reviews



## Screenshots

| Before | After |
|--------|-------|
|<video width="300" src="https://user-images.githubusercontent.com/31601805/116857189-60ac1080-ac37-11eb-9ce5-4521b7e13421.mov">|<video width="300" src="https://user-images.githubusercontent.com/31601805/116857196-6275d400-ac37-11eb-9564-792f13109bc8.mov">|


